### PR TITLE
if self.objectIdentifiers = nil predicate will fail.

### DIFF
--- a/Modules/News/Model/MITNewsStoriesDataSource.m
+++ b/Modules/News/Model/MITNewsStoriesDataSource.m
@@ -183,12 +183,8 @@ static const NSUInteger MITNewsStoriesDataSourceDefaultPageSize = 20;
     fetchRequest.entity = [MITNewsStory entityDescription];
 
     if (![self _canCacheRequest] || self.objectIdentifiers) {
-        fetchRequest.predicate = [NSPredicate predicateWithFormat:@"SELF in %@",self.objectIdentifiers];
-        if (self.objectIdentifiers != nil) {
-            fetchRequest.predicate = [NSPredicate predicateWithFormat:@"SELF in %@",self.objectIdentifiers];
-        } else {
-            fetchRequest.predicate = [NSPredicate predicateWithValue:YES];
-        }
+        NSSet *objectSet = [NSSet setWithSet:[self.objectIdentifiers set]];
+        fetchRequest.predicate = [NSPredicate predicateWithFormat:@"SELF in %@",objectSet];
     } else if (self.categoryIdentifier) {
         fetchRequest.predicate = [NSPredicate predicateWithFormat:@"category.identifier == %@", self.categoryIdentifier];
     }


### PR DESCRIPTION
Fix for search results crashing app.
