### PR TITLE
Fix for collection view cells not appearing when project is built in Xcode 6 running on iOS 7.

### DIFF
--- a/Modules/News/iPad/Views/Collection View Cells/MITNewsStoryCollectionViewCell.m
+++ b/Modules/News/iPad/Views/Collection View Cells/MITNewsStoryCollectionViewCell.m
@@ -159,9 +159,8 @@ static CGSize const MITNewsStoryCellExternalMaximumImageSize = {.width = 133., .
     [self setNeedsLayout];
 }
 
-- (void)commonInit_MyCollectionViewCell
+- (void)commonInit
 {
-    
     if (NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1 ) {
         [[self contentView] setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
     }
@@ -170,7 +169,7 @@ static CGSize const MITNewsStoryCellExternalMaximumImageSize = {.width = 133., .
 - (id)initWithCoder:(NSCoder *)coder
 {
     if (self = [super initWithCoder:coder]) {
-        [self commonInit_MyCollectionViewCell];
+        [self commonInit];
     }
     return self;
 }
@@ -178,7 +177,7 @@ static CGSize const MITNewsStoryCellExternalMaximumImageSize = {.width = 133., .
 - (id)initWithFrame:(CGRect)frame
 {
     if (self = [super initWithFrame:frame]) {
-        [self commonInit_MyCollectionViewCell];
+        [self commonInit];
     }
     return self;
 }


### PR DESCRIPTION
Fix for collection view cells not appearing when project is built in Xcode 6 running on iOS 7.
https://developer.apple.com/library/ios/releasenotes/developertools/rn-xcode/Chapters/Introduction.html.
