### PR TITLE
iOS 8 iPad new sharing fix

### DIFF
--- a/Modules/News/View Controllers/MITNewsMediaGalleryViewController.m
+++ b/Modules/News/View Controllers/MITNewsMediaGalleryViewController.m
@@ -217,8 +217,7 @@
                                                                                             applicationActivities:nil];
         
         sharingViewController.excludedActivityTypes = @[UIActivityTypePrint,
-                                                        UIActivityTypeAssignToContact,
-                                                        UIActivityTypeSaveToCameraRoll];
+                                                        UIActivityTypeAssignToContact];
         
         [sharingViewController setValue:[NSString stringWithFormat:@"MIT News: %@",self.storyTitle] forKeyPath:@"subject"];
         

--- a/Modules/News/View Controllers/MITNewsStoryViewController.m
+++ b/Modules/News/View Controllers/MITNewsStoryViewController.m
@@ -145,8 +145,7 @@
         UIActivityViewController *sharingViewController = [[UIActivityViewController alloc] initWithActivityItems:items
                                                                                             applicationActivities:nil];
         sharingViewController.excludedActivityTypes = @[UIActivityTypePrint,
-                                                        UIActivityTypeAssignToContact,
-                                                        UIActivityTypeSaveToCameraRoll];
+                                                        UIActivityTypeAssignToContact];
 
         if ([sharingViewController respondsToSelector:@selector(popoverPresentationController)]) {
             sharingViewController.popoverPresentationController.barButtonItem = sender;


### PR DESCRIPTION
Must define anchor point.

AVC.popoverPresentationController is introduced in iOS 8 so we must check iOS version.
