### PR TITLE
FIX: Search recents are duplicating iOS 8

### DIFF
--- a/Modules/News/Model/MITNewsRecentSearchQuery.h
+++ b/Modules/News/Model/MITNewsRecentSearchQuery.h
@@ -5,5 +5,6 @@
 @interface MITNewsRecentSearchQuery : MITManagedObject
 
 @property (nonatomic, retain) NSString * text;
+@property (nonatomic, retain) NSDate * date;
 
 @end

--- a/Modules/News/Model/MITNewsRecentSearchQuery.m
+++ b/Modules/News/Model/MITNewsRecentSearchQuery.m
@@ -3,5 +3,5 @@
 @implementation MITNewsRecentSearchQuery
 
 @dynamic text;
-
+@dynamic date;
 @end

--- a/Modules/News/News.xcdatamodeld/News v4.xcdatamodel/contents
+++ b/Modules/News/News.xcdatamodeld/News v4.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="5064" systemVersion="13D65" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6244" systemVersion="13F34" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="NewsCategory" representedClassName="MITNewsCategory" syncable="YES">
         <attribute name="identifier" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
@@ -25,6 +25,7 @@
         <relationship name="recentQueries" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="NewsRecentSearchQuery" syncable="YES"/>
     </entity>
     <entity name="NewsRecentSearchQuery" representedClassName="MITNewsRecentSearchQuery" syncable="YES">
+        <attribute name="date" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <entity name="NewsStory" representedClassName="MITNewsStory" syncable="YES">
@@ -47,8 +48,8 @@
         <element name="NewsCategory" positionX="0" positionY="0" width="128" height="120"/>
         <element name="NewsImage" positionX="0" positionY="0" width="128" height="135"/>
         <element name="NewsImageRep" positionX="0" positionY="0" width="128" height="105"/>
-        <element name="NewsRecentSearchQuery" positionX="0" positionY="0" width="128" height="58"/>
         <element name="NewsRecentSearchList" positionX="0" positionY="0" width="128" height="58"/>
+        <element name="NewsRecentSearchQuery" positionX="0" positionY="0" width="128" height="75"/>
         <element name="NewsStory" positionX="0" positionY="0" width="128" height="255"/>
     </elements>
 </model>


### PR DESCRIPTION
Reworked Recent Search to have a date included.  If object is already in core data it's better to edit the date rather than delete and add the item again.

(referenced new maps recent search)
