### PR TITLE
Refresh control text overlapping indicator

### DIFF
--- a/Modules/News/iPad/View Controllers/MITNewsiPadViewController.m
+++ b/Modules/News/iPad/View Controllers/MITNewsiPadViewController.m
@@ -612,7 +612,7 @@ CGFloat const refreshControlTextHeight = 19;
         return;
     }
     
-    [self setStoryUpdateInProgress:YES];
+    [self setNewsStoryUpdateInProgress:YES];
     [self updateLoadingCell];
     self.loadingMoreStories = YES;
     
@@ -624,7 +624,7 @@ CGFloat const refreshControlTextHeight = 19;
                                      if (!strongSelf) {
                                          return;
                                      }
-                                     [strongSelf setStoryUpdateInProgress:NO];
+                                     [strongSelf setNewsStoryUpdateInProgress:NO];
                                      strongSelf.loadingMoreStories = NO;
                                      
                                      if (error) {
@@ -664,7 +664,7 @@ CGFloat const refreshControlTextHeight = 19;
     }
 }
 
-- (void)setStoryUpdateInProgress:(BOOL)progress
+- (void)setNewsStoryUpdateInProgress:(BOOL)progress
 {
     if (self.presentationStyle == MITNewsPresentationStyleGrid) {
         self.gridViewController.storyUpdateInProgress = progress;


### PR DESCRIPTION
We cannot have setStoryUpdateInProgress as a method because we have a variable named storyUpdateInProgress.
