### PR TITLE
URL decode parameters before passing them to RestKit. Fixes #287

### DIFF
--- a/Common/Core Data/MITMobile.m
+++ b/Common/Core Data/MITMobile.m
@@ -154,7 +154,7 @@ NSString* const MITMobileErrorDomain = @"MITMobileErrorDomain";
                                    relativeToURL:MITMobileWebGetCurrentServerURL()] absoluteURL];
 
         RKObjectManager *objectManager = [self objectManagerForURL:serverURL];
-        NSDictionary *queryParameters = [url queryDictionary];
+        NSDictionary *queryParameters = [url URLDecodedQueryDictionary];
         [objectManager getObjectsAtPath:path
                              parameters:queryParameters
                                 success:^(RKObjectRequestOperation *operation, RKMappingResult *mappingResult) {

--- a/Common/Foundation+MITAdditions.h
+++ b/Common/Foundation+MITAdditions.h
@@ -30,6 +30,7 @@ NSDictionary* MITPagingMetadataFromResponse(NSHTTPURLResponse* response);
  * @see -[NSURL query]
  */
 - (NSDictionary*)queryDictionary;
+- (NSDictionary*)URLDecodedQueryDictionary;
 @end
 
 @interface NSArray (MITAdditions)


### PR DESCRIPTION
AFHTTPClient automatically encodes any parameters passed to it so a value of '+' (which should of been ' ') was being literally interpreted and replaced with %2B.
