### PR TITLE
Refresh Control state

### DIFF
--- a/Modules/News/iPad/View Controllers/MITNewsiPadViewController.m
+++ b/Modules/News/iPad/View Controllers/MITNewsiPadViewController.m
@@ -128,7 +128,7 @@ CGFloat const refreshControlTextHeight = 19;
             [self updateRefreshStatusWithLastUpdatedTime];
         }
         [self updateNavigationItem:YES];
-    } else {
+    } else if (!self.storyUpdateInProgress){
         [self updateRefreshStatusWithLastUpdatedTime];
     }
     


### PR DESCRIPTION
When story update is in progress we do not want to reset refresh control text when coming back from categories / story detail.
