### PR TITLE
Displaying Error message when no stories have been downloaded but header have been downloaded

### DIFF
--- a/Modules/News/iPad/View Controllers/MITNewsiPadViewController.m
+++ b/Modules/News/iPad/View Controllers/MITNewsiPadViewController.m
@@ -529,6 +529,16 @@ CGFloat const refreshControlTextHeight = 19;
                 [strongSelf addNoResultsViewWithMessage:refreshControl.attributedTitle.string];
                 
             } else {
+                BOOL *storyHasBeenDownloaded = NO;
+                for (MITNewsDataSource *datasource in strongSelf.dataSources) {
+                    if ([datasource.objects count] != 0) {
+                        storyHasBeenDownloaded = YES;
+                        break;
+                    }
+                }
+                if (!storyHasBeenDownloaded) {
+                    [strongSelf addNoResultsViewWithMessage:refreshControl.attributedTitle.string];
+                }
                 if (strongRefresh.refreshing) {
                     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(MITNewsRefreshControlHangTime * NSEC_PER_SEC));
                     dispatch_after(popTime, dispatch_get_main_queue(), ^{


### PR DESCRIPTION
{iPad/iPhone - first start} - display failed and do not display the three category headers if there are no stories for the category

References #67
