### PR TITLE
The navigation module's rootViewController should be strong. Fixes #350

### DIFF
--- a/App Delegate/MITNavigationModule.h
+++ b/App Delegate/MITNavigationModule.h
@@ -1,7 +1,7 @@
 #import "MITModule.h"
 
 @interface MITNavigationModule : MITModule
-@property(nonatomic,weak) UINavigationController *navigationController;
+@property(nonatomic,strong) UINavigationController *navigationController;
 @property(nonatomic,strong) UIViewController *rootViewController;
 
 - (instancetype)initWithName:(NSString *)name title:(NSString *)title;

--- a/Modules/About/AboutModule.h
+++ b/Modules/About/AboutModule.h
@@ -2,7 +2,7 @@
 #import "AboutTableViewController.h"
 
 @interface AboutModule : MITNavigationModule
-@property(nonatomic,weak) AboutTableViewController *rootViewController;
+@property(nonatomic,strong) AboutTableViewController *rootViewController;
 
 - (instancetype)init;
 @end

--- a/Modules/Emergency/EmergencyModule.h
+++ b/Modules/Emergency/EmergencyModule.h
@@ -2,7 +2,7 @@
 #import "EmergencyViewController.h"
 
 @interface EmergencyModule : MITNavigationModule <EmergencyViewControllerDelegate>
-@property(nonatomic,weak) EmergencyViewController *rootViewController;
+@property(nonatomic,strong) EmergencyViewController *rootViewController;
 
 - (instancetype)init;
 

--- a/Modules/Facilities/FacilitiesModule.h
+++ b/Modules/Facilities/FacilitiesModule.h
@@ -4,7 +4,7 @@
 #import "FacilitiesRootViewController.h"
 
 @interface FacilitiesModule : MITNavigationModule
-@property(nonatomic,weak) FacilitiesRootViewController *rootViewController;
+@property(nonatomic,strong) FacilitiesRootViewController *rootViewController;
 
 - (instancetype)init;
 @end

--- a/Modules/Libraries/LibrariesModule.h
+++ b/Modules/Libraries/LibrariesModule.h
@@ -3,7 +3,7 @@
 #import "LibrariesViewController.h"
 
 @interface LibrariesModule : MITNavigationModule
-@property(nonatomic,weak) LibrariesViewController *rootViewController;
+@property(nonatomic,strong) LibrariesViewController *rootViewController;
 @property(nonatomic,strong) NSOperationQueue *requestQueue;
 
 - (instancetype)init;

--- a/Modules/Links/LinksModule.h
+++ b/Modules/Links/LinksModule.h
@@ -3,7 +3,7 @@
 #import "LinksViewController.h"
 
 @interface LinksModule : MITNavigationModule
-@property(nonatomic,weak) LinksViewController *rootViewController;
+@property(nonatomic,strong) LinksViewController *rootViewController;
 
 - (instancetype)init;
 @end


### PR DESCRIPTION
Subclasses should also use _strong_ semantics when re-declaring the type.
