### PR TITLE
3.6/news search

### DIFF
--- a/Modules/News/iPad/View Controllers/MITNewsSearchController.m
+++ b/Modules/News/iPad/View Controllers/MITNewsSearchController.m
@@ -86,8 +86,6 @@
 
 - (void)searchBarSearchButtonClicked:(UISearchBar *)searchBar
 {
-    [self hideSearchRecents];
-    [self.recentSearchController addRecentSearchItem:searchBar.text];
     [self getResultsForString:searchBar.text];
 }
 
@@ -142,6 +140,9 @@
 #pragma mark - search
 - (void)getResultsForString:(NSString *)searchTerm
 {
+    [self hideSearchRecents];
+    [self.recentSearchController addRecentSearchItem:searchTerm];
+
     [self changeToSearchStories];
     [self.view removeGestureRecognizer:self.resignSearchTapGestureRecognizer];
     [self removeNoResultsView];


### PR DESCRIPTION
Show search results only when search field is blank or when changing the search field.

When clicking on search recent results are now shown.
