### PR TITLE
3.6 news search cancel fix iPhone

### DIFF
--- a/Modules/News/iPad/View Controllers/MITNewsSearchController.m
+++ b/Modules/News/iPad/View Controllers/MITNewsSearchController.m
@@ -106,9 +106,11 @@
         self.messageView.alpha = .5;
         self.messageActivityView.alpha = .5;
     } else {
-        if ([searchBar.text isEqualToString:@""]) {
-            [self showTableSearchRecents];
-            self.view.alpha = 1;
+        if (!self.dataSource.isUpdating && ![self.dataSource.objects count]) {
+            if ([searchBar.text isEqualToString:@""]) {
+                [self showTableSearchRecents];
+                self.view.alpha = 1;
+            }
         }
     }
 }


### PR DESCRIPTION
Don't need to nil out self.recentSearchController since it is used throughout the Implementation.

Instead of bringing back recent search when clicking (x) when searching we continue with the loading process and show the stories just like the iPad does.
