### PR TITLE
disable shuttle animation Closes #439

### DIFF
--- a/Modules/ShuttleTrack/MITShuttleMapBusAnnotationView.m
+++ b/Modules/ShuttleTrack/MITShuttleMapBusAnnotationView.m
@@ -186,7 +186,7 @@
 
 - (void)didMoveAnnotation:(NSNotification *)notification
 {
-    [self updateVehicle:[notification object] animated:YES];
+    [self updateVehicle:[notification object] animated:NO];
 }
 
 - (void)updateVehicle:(MITShuttleVehicle *)vehicle animated:(BOOL)animated


### PR DESCRIPTION
Shouldn’t animate vehicles to their next location. Vehicles should just jump to their next location (animating takes time, during which the actual reported location isn’t yet being shown).
Closes #439
