### PR TITLE
Libraries open hours are offset by one day. Fixes #886

### DIFF
--- a/Common/Categories/Foundation+MITAdditions.h
+++ b/Common/Categories/Foundation+MITAdditions.h
@@ -116,6 +116,7 @@ NSDictionary* MITPagingMetadataFromResponse(NSHTTPURLResponse* response);
 - (NSDateComponents *)timeComponents;
 - (NSDate *)dateWithTimeOfDayFromDate:(NSDate *)date;
 - (BOOL)dateFallsBetweenStartDate:(NSDate *)startDate endDate:(NSDate *)endDate;
+- (BOOL)dateFallsBetweenStartDate:(NSDate *)startDate endDate:(NSDate *)endDate components:(NSCalendarUnit)components;
 - (NSString *)ISO8601String;
 - (NSString *)MITDateCode;
 + (NSNumber *)numberForDateCode:(NSString *)dateCode;

--- a/Common/Categories/Foundation+MITAdditions.m
+++ b/Common/Categories/Foundation+MITAdditions.m
@@ -698,10 +698,11 @@ typedef struct {
 {
     NSCalendar *calendar = [NSCalendar cachedCurrentCalendar];
     
-    NSDate *date1 = [calendar dateFromComponents:[calendar components:components
-                                                             fromDate:self]];
-    NSDate *date2 = [calendar dateFromComponents:[calendar components:components
-                                                             fromDate:otherDate]];
+    NSDateComponents *dateComponents1 = [calendar components:components fromDate:self];
+    NSDateComponents *dateComponents2 = [calendar components:components fromDate:otherDate];
+    
+    NSDate *date1 = [calendar dateFromComponents:dateComponents1];
+    NSDate *date2 = [calendar dateFromComponents:dateComponents2];
     
 	return [date1 isEqual:date2];
 }

--- a/Common/Categories/Foundation+MITAdditions.m
+++ b/Common/Categories/Foundation+MITAdditions.m
@@ -965,8 +965,13 @@ typedef struct {
 
 - (BOOL)dateFallsBetweenStartDate:(NSDate *)startDate endDate:(NSDate *)endDate
 {
-    return ([self timeIntervalSince1970] >= [startDate timeIntervalSince1970] &&
-            [self timeIntervalSince1970] <= [endDate timeIntervalSince1970]);
+    NSParameterAssert(startDate);
+    NSParameterAssert(endDate);
+    
+    NSComparisonResult startDateComparison = [self compare:startDate];
+    NSComparisonResult endDateComparison = [self compare:endDate];
+    
+    return ((startDateComparison != NSOrderedAscending) && (endDateComparison != NSOrderedDescending));
 }
 
 - (NSString *)ISO8601String

--- a/Common/Categories/Foundation+MITAdditions.m
+++ b/Common/Categories/Foundation+MITAdditions.m
@@ -1020,30 +1020,29 @@ typedef struct {
     }
 }
 
+// Returns an NSNumber representing an index into
+// -[NSDateFormatter weekdaySymbols]. This index is
+// zero-indexed (unlike -[NSDateComponents weekday])
 + (NSNumber *)numberForDateCode:(NSString *)dateCode
 {
     if ([dateCode isEqualToString:@"U"]) {
         return @0;
-    }
-    else if ([dateCode isEqualToString:@"M"]) {
+    } else if ([dateCode isEqualToString:@"M"]) {
         return @1;
-    }
-    else if ([dateCode isEqualToString:@"T"]) {
+    } else if ([dateCode isEqualToString:@"T"]) {
         return @2;
-    }
-    else if ([dateCode isEqualToString:@"W"]) {
+    } else if ([dateCode isEqualToString:@"W"]) {
         return @3;
-    }
-    else if ([dateCode isEqualToString:@"R"]) {
+    } else if ([dateCode isEqualToString:@"R"]) {
         return @4;
-    }
-    else if ([dateCode isEqualToString:@"F"]) {
+    } else if ([dateCode isEqualToString:@"F"]) {
         return @5;
-    }
-    else if ([dateCode isEqualToString:@"S"]) {
+    } else if ([dateCode isEqualToString:@"S"]) {
         return @6;
+    } else {
+        NSString *reason = [NSString stringWithFormat:@"unknown date code %@", dateCode];
+        @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil];
     }
-    return @0;
 }
 
 @end

--- a/Common/Categories/Foundation+MITAdditions.m
+++ b/Common/Categories/Foundation+MITAdditions.m
@@ -984,13 +984,8 @@ typedef struct {
 
 - (NSString *)MITDateCode
 {
-    static NSDateComponents *dateComponents;
-    if (!dateComponents) {
-        NSCalendar *calendar = [NSCalendar currentCalendar];
-        dateComponents = [calendar components:(NSDayCalendarUnit |
-                                               NSWeekdayCalendarUnit)
-                                      fromDate:self];
-    }
+    NSCalendarUnit calendarUnits = (NSDayCalendarUnit | NSWeekdayCalendarUnit);
+    NSDateComponents *dateComponents = [[NSCalendar cachedCurrentCalendar] components:calendarUnits fromDate:self];
  
     switch (dateComponents.weekday) {
         case 1: {

--- a/Common/Categories/Foundation+MITAdditions.m
+++ b/Common/Categories/Foundation+MITAdditions.m
@@ -993,30 +993,37 @@ typedef struct {
     }
  
     switch (dateComponents.weekday) {
-        case 0:
+        case 1: {
             return @"U";
-            break;
-        case 1:
+        }
+            
+        case 2: {
             return @"M";
-            break;
-        case 2:
+        }
+            
+        case 3: {
             return @"T";
-            break;
-        case 3:
+        }
+            
+        case 4: {
             return @"W";
-            break;
-        case 4:
+        }
+            
+        case 5: {
             return @"R";
-            break;
-        case 5:
+        }
+            
+        case 6: {
             return @"F";
-            break;
-        case 6:
+        }
+            
+        case 7: {
             return @"S";
-            break;
-        default:
-            return @"";
-            break;
+        }
+            
+        default: {
+            return nil;
+        }
     }
 }
 
@@ -1059,7 +1066,6 @@ typedef struct {
 + (NSCalendar *)cachedCurrentCalendar {
     return (NSCalendar*)CFBridgingRelease(CFCalendarCopyCurrent());
 }
-
 @end
 
 @implementation NSIndexPath (MITAdditions)

--- a/Common/Categories/Foundation+MITAdditions.m
+++ b/Common/Categories/Foundation+MITAdditions.m
@@ -974,6 +974,23 @@ typedef struct {
     return ((startDateComparison != NSOrderedAscending) && (endDateComparison != NSOrderedDescending));
 }
 
+- (BOOL)dateFallsBetweenStartDate:(NSDate *)startDate endDate:(NSDate *)endDate components:(NSCalendarUnit)components
+{
+    NSParameterAssert(startDate);
+    NSParameterAssert(endDate);
+    
+    NSCalendar *calendar = [NSCalendar cachedCurrentCalendar];
+    NSDateComponents *currentDateComponents = [calendar components:components fromDate:self];
+    NSDateComponents *startDateComponents = [calendar components:components fromDate:startDate];
+    NSDateComponents *endDateComponents = [calendar components:components fromDate:endDate];
+    
+    NSDate *currentDate = [calendar dateFromComponents:currentDateComponents];
+    startDate = [calendar dateFromComponents:startDateComponents];
+    endDate = [calendar dateFromComponents:endDateComponents];
+    
+    return [currentDate dateFallsBetweenStartDate:startDate endDate:endDate];
+}
+
 - (NSString *)ISO8601String
 {
 	struct tm *timeinfo;

--- a/Modules/Libraries/MITLibrariesClosingsTerm.m
+++ b/Modules/Libraries/MITLibrariesClosingsTerm.m
@@ -24,16 +24,7 @@ static NSString * const MITLibrariesClosingTermCodingKeyReason = @"MITLibrariesC
 
 - (BOOL)isClosedOnDate:(NSDate *)date
 {
-    return ([date dateFallsBetweenStartDate:self.dates.startDate endDate:self.dates.endDate]);
-}
-
-- (NSDateFormatter *)dateFormatter
-{
-    static NSDateFormatter *dateFormatter;
-    if (!dateFormatter) {
-        dateFormatter = [[NSDateFormatter alloc] init];
-    }
-    return dateFormatter;
+    return ([date dateFallsBetweenStartDate:self.dates.startDate endDate:self.dates.endDate components:(NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit)]);
 }
 
 #pragma mark - NSCoding

--- a/Modules/Libraries/MITLibrariesRegularTerm.m
+++ b/Modules/Libraries/MITLibrariesRegularTerm.m
@@ -119,17 +119,12 @@ static NSString * const MITLibrariesRegularTermCodingKeyHours = @"MITLibrariesRe
     NSAssert(startWeekdaySymbol <= endWeekdaySymbol, @"The week cannot start before it ends!");
     
     NSMutableString *rangeString = [[NSMutableString alloc] init];
-
-    // Increment the length of the range by 1 because the range should be
-    // inclusive of the ending day.
-    NSRange weekdayRange = NSMakeRange(startWeekdaySymbol, (endWeekdaySymbol - startWeekdaySymbol) + 1);
-    NSIndexSet *indexes = [NSIndexSet indexSetWithIndexesInRange:weekdayRange];
-    NSArray *weekdays = [self.dateFormatter.weekdaySymbols objectsAtIndexes:indexes];
+    NSArray *weekdaySymbols = self.dateFormatter.weekdaySymbols;
     
-    if (weekdayRange.length == 1) {
-        [rangeString appendString:[weekdays firstObject]];
+    if (startWeekdaySymbol == endWeekdaySymbol) {
+        [rangeString appendString:weekdaySymbols[startWeekdaySymbol]];
     } else {
-        [rangeString appendFormat:@"%@-%@",[weekdays firstObject],[weekdays lastObject]];
+        [rangeString appendFormat:@"%@-%@",weekdaySymbols[startWeekdaySymbol],weekdaySymbols[endWeekdaySymbol]];
     }
     
     NSAssert(rangeString.length, @"invalid day range");

--- a/Modules/Libraries/MITLibrariesRegularTerm.m
+++ b/Modules/Libraries/MITLibrariesRegularTerm.m
@@ -92,7 +92,6 @@ static NSString * const MITLibrariesRegularTermCodingKeyHours = @"MITLibrariesRe
         [rangeString appendFormat:@"%@-%@",weekdaySymbols[startWeekdaySymbol],weekdaySymbols[endWeekdaySymbol]];
     }
     
-    NSAssert(rangeString.length, @"invalid day range");
     return rangeString;
 }
 


### PR DESCRIPTION
Fixes an issue where the open hours displayed for each of the MIT libraries was being offset by one day (for example, Thursday would show Friday's hours).