### PR TITLE
Header wasn't sizing correct on 4s so made the header a tableviewcell and created enum for table rows #952

### DIFF
--- a/MIT Mobile.xcodeproj/project.pbxproj
+++ b/MIT Mobile.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B1E9A5E1ADEF67900B4212F /* MITMobiusQuickSearchHeaderTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B1E9A5C1ADEF67900B4212F /* MITMobiusQuickSearchHeaderTableViewCell.m */; };
+		0B1E9A5F1ADEF67900B4212F /* MITMobiusQuickSearchHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0B1E9A5D1ADEF67900B4212F /* MITMobiusQuickSearchHeaderTableViewCell.xib */; };
 		0B22CAB21A95277500A171A4 /* MITMobiusMapViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B22CAB11A95277500A171A4 /* MITMobiusMapViewController.m */; };
 		0B22CAC41A952D9500A171A4 /* MITMobiusMapViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0B22CAC21A952D9500A171A4 /* MITMobiusMapViewController.xib */; };
 		0B34E4281A081EC1002CF7F1 /* MITNewsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B1689D01937D1EB001EB3B1 /* MITNewsViewController.m */; };
@@ -740,6 +742,9 @@
 /* Begin PBXFileReference section */
 		0B1689CF1937D1EB001EB3B1 /* MITNewsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MITNewsViewController.h; sourceTree = "<group>"; };
 		0B1689D01937D1EB001EB3B1 /* MITNewsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MITNewsViewController.m; sourceTree = "<group>"; };
+		0B1E9A5B1ADEF67900B4212F /* MITMobiusQuickSearchHeaderTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MITMobiusQuickSearchHeaderTableViewCell.h; path = Views/MITMobiusQuickSearchHeaderTableViewCell.h; sourceTree = "<group>"; };
+		0B1E9A5C1ADEF67900B4212F /* MITMobiusQuickSearchHeaderTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MITMobiusQuickSearchHeaderTableViewCell.m; path = Views/MITMobiusQuickSearchHeaderTableViewCell.m; sourceTree = "<group>"; };
+		0B1E9A5D1ADEF67900B4212F /* MITMobiusQuickSearchHeaderTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = MITMobiusQuickSearchHeaderTableViewCell.xib; path = Views/MITMobiusQuickSearchHeaderTableViewCell.xib; sourceTree = "<group>"; };
 		0B22CAB01A95277500A171A4 /* MITMobiusMapViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MITMobiusMapViewController.h; sourceTree = "<group>"; };
 		0B22CAB11A95277500A171A4 /* MITMobiusMapViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MITMobiusMapViewController.m; sourceTree = "<group>"; };
 		0B22CAC21A952D9500A171A4 /* MITMobiusMapViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MITMobiusMapViewController.xib; sourceTree = "<group>"; };
@@ -3199,6 +3204,9 @@
 				0BAE71891ADC3D15008B0CAF /* MITMobiusRootHeader.h */,
 				0BAE718A1ADC3D15008B0CAF /* MITMobiusRootHeader.m */,
 				0BAE718C1ADC3D30008B0CAF /* MITMobiusRootHeader.xib */,
+				0B1E9A5B1ADEF67900B4212F /* MITMobiusQuickSearchHeaderTableViewCell.h */,
+				0B1E9A5C1ADEF67900B4212F /* MITMobiusQuickSearchHeaderTableViewCell.m */,
+				0B1E9A5D1ADEF67900B4212F /* MITMobiusQuickSearchHeaderTableViewCell.xib */,
 				0BAE718F1ADC4439008B0CAF /* MITMobiusQuickSearchTableViewCell.h */,
 				0BAE71901ADC4439008B0CAF /* MITMobiusQuickSearchTableViewCell.m */,
 				0BAE718E1ADC4439008B0CAF /* MITMobiusQuickSearchTableViewCell.xib */,
@@ -5149,6 +5157,7 @@
 				277A583019FD70BA00BE134E /* MITFacilities_iphone.storyboard in Resources */,
 				0BE0C4131975B95900961025 /* MITNewsSearchController.xib in Resources */,
 				22E6BCC119E472D8003E278C /* MITLibrariesYourAccountViewControllerPad.xib in Resources */,
+				0B1E9A5F1ADEF67900B4212F /* MITMobiusQuickSearchHeaderTableViewCell.xib in Resources */,
 				2C95A1D9137DB24D0025B28D /* FacilitiesSummaryViewController.xib in Resources */,
 				A544EF0C19647FA30046823E /* MITMapPlaceDetailViewController.xib in Resources */,
 				2CB5E8581A700E240012F034 /* Mobius_phone.storyboard in Resources */,
@@ -5774,6 +5783,7 @@
 				22D9032E199BFEC100AEBC7D /* MITDiningHouseVenueListViewController.m in Sources */,
 				80598DC01A0A81780095CEAA /* MITLibrariesFormSheetCellMultiLineTextEntry.m in Sources */,
 				80C5D9E31A111BB300E63FDD /* MITLibrariesFormSheetElementTimeframe.m in Sources */,
+				0B1E9A5E1ADEF67900B4212F /* MITMobiusQuickSearchHeaderTableViewCell.m in Sources */,
 				806205741A7AAF1A004BD08A /* ModuleVersions.m in Sources */,
 				22D90308199BA90E00AEBC7D /* MITDiningHouseVenue.m in Sources */,
 				0BCC90C71963188A00440544 /* MITNewsRecentSearchQuery.m in Sources */,

--- a/Modules/Mobius/View Controllers/MITMobiusRootPhoneViewController.m
+++ b/Modules/Mobius/View Controllers/MITMobiusRootPhoneViewController.m
@@ -19,9 +19,16 @@
 #import "MITMobiusQuickSearchTableViewController.h"
 #import "MITMobiusRoomSet.h"
 #import "MITMobiusResourceType.h"
+#import "MITMobiusQuickSearchHeaderTableViewCell.h"
 
+typedef NS_ENUM(NSInteger, MITMobiusQuickSearchTableViewRows) {
+    MITMobiusQuickSearchHeaderTableRow = 0,
+    MITMobiusQuickSearchRoomSetTableRow,
+    MITMobiusQuickSearchResourceTypeTableRow,
+};
 
 static NSString * const MITMobiusQuickSearchTableViewCellIdentifier = @"MITMobiusQuickSearchTableViewCellIdentifier";
+static NSString * const MITMobiusQuickSearchHeaderTableViewCellIdentifier = @"MITMobiusQuickSearchHeaderTableViewCellIdentifier";
 
 static NSTimeInterval MITMobiusRootPhoneDefaultAnimationDuration = 0.33;
 
@@ -104,40 +111,14 @@ typedef NS_ENUM(NSInteger, MITMobiusRootViewControllerState) {
     self.recentSearchViewController.view.alpha = 0.;
 }
 
-- (void)viewDidAppear:(BOOL)animated
-{
-    [super viewDidAppear:animated];
-    [self setupTableViewHeader:self.quickLookupTableView];
-}
-
 - (void)setupTableView:(UITableView *)tableView
 {
     [self.quickLookupTableView registerNib:[MITMobiusQuickSearchTableViewCell quickSearchCellNib] forDynamicCellReuseIdentifier:MITMobiusQuickSearchTableViewCellIdentifier];
+    
+    [self.quickLookupTableView registerNib:[MITMobiusQuickSearchHeaderTableViewCell quickSearchHeaderCellNib] forDynamicCellReuseIdentifier:MITMobiusQuickSearchHeaderTableViewCellIdentifier];
 
     tableView.tableFooterView = [UIView new];
     tableView.backgroundColor = [UIColor colorWithRed:239.0/255.0 green:239.0/255.0 blue:244.0/255.0 alpha:1];
-}
-
-- (void)setupTableViewHeader:(UITableView *)tableView
-{
-    if (tableView.tableHeaderView) {
-        return;
-    }
-    MITMobiusRootHeader *quickSearchHeader = [[[NSBundle mainBundle]
-                                            loadNibNamed:@"MITMobiusRootHeader"
-                                            owner:self options:nil]
-                                           firstObject];
-    tableView.tableHeaderView = quickSearchHeader;
-    
-    [quickSearchHeader setNeedsLayout];
-    [quickSearchHeader layoutIfNeeded];
-    CGFloat height = [quickSearchHeader systemLayoutSizeFittingSize:UILayoutFittingCompressedSize].height;
-    
-    //update the header's frame and set it again
-    CGRect tableHeaderViewFrame = quickSearchHeader.frame;
-    tableHeaderViewFrame.size.height = height;
-    quickSearchHeader.frame = tableHeaderViewFrame;
-    tableView.tableHeaderView = quickSearchHeader;
 }
 
 - (void)viewDidLayoutSubviews
@@ -888,7 +869,7 @@ typedef NS_ENUM(NSInteger, MITMobiusRootViewControllerState) {
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    return 2;
+    return 3;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -911,9 +892,11 @@ typedef NS_ENUM(NSInteger, MITMobiusRootViewControllerState) {
 
 - (NSString*)reuseIdentifierForRowAtIndexPath:(NSIndexPath*)indexPath
 {
-    if (indexPath.row == MITMobiusQuickSearchResourceType ||
-        indexPath.row == MITMobiusQuickSearchRoomSet) {
+    if (indexPath.row == MITMobiusQuickSearchResourceTypeTableRow ||
+        indexPath.row == MITMobiusQuickSearchRoomSetTableRow) {
         return MITMobiusQuickSearchTableViewCellIdentifier;
+    } else if (indexPath.row == MITMobiusQuickSearchHeaderTableRow) {
+        return MITMobiusQuickSearchHeaderTableViewCellIdentifier;
     }
     return nil;
 }
@@ -921,7 +904,7 @@ typedef NS_ENUM(NSInteger, MITMobiusRootViewControllerState) {
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
-    if (indexPath.row == MITMobiusQuickSearchResourceType) {
+    if (indexPath.row == MITMobiusQuickSearchResourceTypeTableRow) {
         MITMobiusQuickSearchTableViewController *quickSearchVC = [[MITMobiusQuickSearchTableViewController alloc] init];
         quickSearchVC.dataSource = self.dataSource;
         quickSearchVC.typeOfObjects = MITMobiusQuickSearchResourceType;
@@ -929,7 +912,7 @@ typedef NS_ENUM(NSInteger, MITMobiusRootViewControllerState) {
         quickSearchVC.title = @"Machine Types";
         [self.navigationController pushViewController:quickSearchVC animated:YES];
 
-    } else if (indexPath.row == MITMobiusQuickSearchRoomSet) {
+    } else if (indexPath.row == MITMobiusQuickSearchRoomSetTableRow) {
         MITMobiusQuickSearchTableViewController *quickSearchVC = [[MITMobiusQuickSearchTableViewController alloc] init];
         quickSearchVC.dataSource = self.dataSource;
         quickSearchVC.typeOfObjects = MITMobiusQuickSearchRoomSet;
@@ -943,14 +926,19 @@ typedef NS_ENUM(NSInteger, MITMobiusRootViewControllerState) {
 - (void)tableView:(UITableView*)tableView configureCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath
 {
     NSString *reuseIdentifier = [self reuseIdentifierForRowAtIndexPath:indexPath];
-
+    if (reuseIdentifier == MITMobiusQuickSearchHeaderTableViewCellIdentifier) {
+        MITMobiusQuickSearchHeaderTableViewCell *quickSearch = (MITMobiusQuickSearchHeaderTableViewCell*)cell;
+        quickSearch.label.text = @"Sample searches:\nMaterials + machine capability: ‘plastic steel hole’\nShop + machine type: ‘Edgerton lathe’";
+        quickSearch.backgroundColor = [UIColor clearColor];
+        quickSearch.selectionStyle = UITableViewCellSelectionStyleNone;
+    }
     if (reuseIdentifier != MITMobiusQuickSearchTableViewCellIdentifier) {
         return;
     }
-    if (indexPath.row == MITMobiusQuickSearchRoomSet) {
+    if (indexPath.row == MITMobiusQuickSearchRoomSetTableRow) {
         MITMobiusQuickSearchTableViewCell *quickSearch = (MITMobiusQuickSearchTableViewCell*)cell;
         quickSearch.label.text = @"Shops & Labs";
-    } else if (indexPath.row == MITMobiusQuickSearchResourceType) {
+    } else if (indexPath.row == MITMobiusQuickSearchResourceTypeTableRow) {
         MITMobiusQuickSearchTableViewCell *quickSearch = (MITMobiusQuickSearchTableViewCell*)cell;
         quickSearch.label.text = @"Machine Types";
     }

--- a/Modules/Mobius/Views/MITMobiusQuickSearchHeaderTableViewCell.h
+++ b/Modules/Mobius/Views/MITMobiusQuickSearchHeaderTableViewCell.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+@interface MITMobiusQuickSearchHeaderTableViewCell : UITableViewCell
+
++ (UINib *)quickSearchHeaderCellNib;
++ (NSString *)quickSearchHeaderCellNibName;
+@property (weak, nonatomic) IBOutlet UILabel *label;
+
+@end

--- a/Modules/Mobius/Views/MITMobiusQuickSearchHeaderTableViewCell.m
+++ b/Modules/Mobius/Views/MITMobiusQuickSearchHeaderTableViewCell.m
@@ -1,0 +1,23 @@
+#import "MITMobiusQuickSearchHeaderTableViewCell.h"
+
+@implementation MITMobiusQuickSearchHeaderTableViewCell
+
+- (void)awakeFromNib
+{
+}
+
++ (UINib *)quickSearchHeaderCellNib
+{
+    return [UINib nibWithNibName:self.quickSearchHeaderCellNibName bundle:nil];
+}
+
++ (NSString *)quickSearchHeaderCellNibName
+{
+    return @"MITMobiusQuickSearchHeaderTableViewCell";
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+}
+
+@end

--- a/Modules/Mobius/Views/MITMobiusQuickSearchHeaderTableViewCell.xib
+++ b/Modules/Mobius/Views/MITMobiusQuickSearchHeaderTableViewCell.xib
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="128" id="KGk-i7-Jjw" customClass="MITMobiusQuickSearchHeaderTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="768" height="128"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="768" height="43"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="319" translatesAutoresizingMaskIntoConstraints="NO" id="GcH-Qy-82k" userLabel="Sample searches: Materials + machine capability: ‘plastic steel hole’ Shop + machine type: ‘Edgerton lathe’" customClass="MultiLineLabel">
+                        <rect key="frame" x="15" y="30" width="753" height="67.5"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="66" id="Zsl-7x-Tr7"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="14"/>
+                        <color key="textColor" red="0.37647058820000001" green="0.37647058820000001" blue="0.37647058820000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <nil key="highlightedColor"/>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="Zsl-7x-Tr7"/>
+                            </mask>
+                        </variation>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="GcH-Qy-82k" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="30" id="6lg-jJ-5Qs"/>
+                    <constraint firstItem="GcH-Qy-82k" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="15" id="oqz-fk-V2y"/>
+                    <constraint firstAttribute="bottom" secondItem="GcH-Qy-82k" secondAttribute="bottom" constant="30" id="vHR-eG-wTy"/>
+                    <constraint firstAttribute="trailing" secondItem="GcH-Qy-82k" secondAttribute="trailing" id="xzo-aW-c9M"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="label" destination="GcH-Qy-82k" id="mbh-zM-8lb"/>
+            </connections>
+            <point key="canvasLocation" x="219" y="255"/>
+        </tableViewCell>
+    </objects>
+</document>


### PR DESCRIPTION
Header wasn't sizing correct on 4s so made the header a tableviewcell and created enum for table rows #952
Tableview header was set at a fixed height so auto layout would work.  

To remedy this the header was made a cell and an enum was created to say what row is displayed at a certain index.