### PR TITLE
Fixes for 4.0.2 (4.0.2.1)

### DIFF
--- a/MIT Mobile Tests/AccessibilityConstants/MITAccessibilityConstants.m
+++ b/MIT Mobile Tests/AccessibilityConstants/MITAccessibilityConstants.m
@@ -28,8 +28,8 @@ NSString * const MITAccessibilityLibrariesHomeSearchBarLabel = @"Libraries Home 
 // Corresponds to the visible text in the cells on the home screen
 NSString * const MITAccessibilityLibrariesHomeCellYourAccount = @"Your Account";
 NSString * const MITAccessibilityLibrariesHomeCellLocations = @"Locations";
-NSString * const MITAccessibilityLibrariesHomeCellAskUs = @"Ask Us!";
-NSString * const MITAccessibilityLibrariesHomeCellTellUs = @"Tell Us!";
+NSString * const MITAccessibilityLibrariesHomeCellAskUs = @"Ask Us";
+NSString * const MITAccessibilityLibrariesHomeCellTellUs = @"Tell Us";
 NSString * const MITAccessibilityLibrariesHomeCellExternalLinkResearch = @"Mobile tools for library research";
 NSString * const MITAccessibilityLibrariesHomeCellExternalLinkNews = @"MIT Libraries News";
 NSString * const MITAccessibilityLibrariesHomeCellExternalLinkWebsite = @"Full MIT Libraries website";

--- a/MIT_Mobile-Info.plist
+++ b/MIT_Mobile-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.2</string>
+	<string>4.0.2.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.education</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Modules/Libraries/AskUsTellUs/AskUsFormSheet/MITLibrariesAskUsFormSheetViewController.m
+++ b/Modules/Libraries/AskUsTellUs/AskUsFormSheet/MITLibrariesAskUsFormSheetViewController.m
@@ -19,7 +19,7 @@
 - (void)setup
 {
     [super setup];
-    self.title = @"Ask Us!";
+    self.title = @"Ask Us";
     [self fetchFormSheetGroups];
 }
 

--- a/Modules/Libraries/AskUsTellUs/AskUsHome/MITLibrariesAskUsHomeViewController.m
+++ b/Modules/Libraries/AskUsTellUs/AskUsHome/MITLibrariesAskUsHomeViewController.m
@@ -104,13 +104,13 @@ static CGFloat const MITLibrariesAskUsHomeCellPadding = 38.0;
     NSString *titleText;
     switch ([self askUsOptionForIndexPath:indexPath]) {
         case MITLibrariesAskUsOptionAskUs:
-            titleText = @"Ask Us!";
+            titleText = @"Ask Us";
             break;
         case MITLibrariesAskUsOptionConsultation:
             titleText = @"Make a research consultation appointment";
             break;
         case MITLibrariesAskUsOptionTellUs:
-            titleText = @"Tell Us!";
+            titleText = @"Tell Us";
             break;
         case MITLibrariesAskUsOptionGeneral:
             titleText = @"General Help";

--- a/Modules/Libraries/MITLibrariesHomeViewController.m
+++ b/Modules/Libraries/MITLibrariesHomeViewController.m
@@ -236,13 +236,13 @@ static NSString * const kMITLibrariesHomeViewControllerDefaultCellIdentifier = @
             break;
         }
         case kMITLibrariesHomeViewControllerMainSectionAskUsRow: {
-            cell.textLabel.text = @"Ask Us!";
+            cell.textLabel.text = @"Ask Us";
             cell.accessoryView = nil;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             break;
         }
         case kMITLibrariesHomeViewControllerMainSectionTellUsRow: {
-            cell.textLabel.text = @"Tell Us!";
+            cell.textLabel.text = @"Tell Us";
             cell.accessoryView = [UIImageView accessoryViewWithMITType:MITAccessoryViewSecure];
             break;
         }

--- a/Modules/Libraries/MITLibrariesHomeViewController.m
+++ b/Modules/Libraries/MITLibrariesHomeViewController.m
@@ -230,7 +230,7 @@ static NSString * const kMITLibrariesHomeViewControllerDefaultCellIdentifier = @
             break;
         }
         case kMITLibrariesHomeViewControllerMainSectionLocationHoursRow: {
-            cell.textLabel.text = @"Locations & Hours";
+            cell.textLabel.text = @"Hours & Locations";
             cell.accessoryView = nil;
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             break;

--- a/Modules/Libraries/MITLibrariesHomeViewControllerPad.m
+++ b/Modules/Libraries/MITLibrariesHomeViewControllerPad.m
@@ -230,7 +230,7 @@ static CGSize const MITLibrariesHomeViewControllerPadFormSheetPresentationPrefer
 - (void)setupToolbar
 {
     self.navigationController.toolbar.translucent = NO;
-    self.locationsAndHoursButton = [[UIBarButtonItem alloc] initWithTitle:@"Locations & Hours" style:UIBarButtonItemStylePlain target:self action:@selector(locationsAndHoursPressed:)];
+    self.locationsAndHoursButton = [[UIBarButtonItem alloc] initWithTitle:@"Hours & Locations" style:UIBarButtonItemStylePlain target:self action:@selector(locationsAndHoursPressed:)];
     self.askUsTellUsButton = [[UIBarButtonItem alloc] initWithTitle:@"Ask Us/Tell Us" style:UIBarButtonItemStylePlain target:self action:@selector(askUsTellUsPressed:)];
     self.quickLinksButton = [[UIBarButtonItem alloc] initWithTitle:@"Quick Links" style:UIBarButtonItemStylePlain target:self action:@selector(quickLinksPressed:)];
     

--- a/Modules/Libraries/MITLibrariesLocationsHoursViewController.m
+++ b/Modules/Libraries/MITLibrariesLocationsHoursViewController.m
@@ -19,7 +19,7 @@ static NSString * const kMITLibraryUserDefaultsKeyLocationAndHours = @"kMITLibra
 {
     [super viewDidLoad];
     
-    self.title = @"Locations & Hours";
+    self.title = @"Hours & Locations";
     
     [self setupTableView];
     

--- a/Modules/Tours/MITToursWebservices.m
+++ b/Modules/Tours/MITToursWebservices.m
@@ -52,7 +52,7 @@
 
 + (NSString *)aboutMITURLString
 {
-    return @"http://web.mit.edu/institute-events/events/";
+    return @"http://web.mit.edu/institute-events/events/tour.html";
 }
 
 + (NSString *)aboutGuidedToursText


### PR DESCRIPTION
Addresses the following issues:
- In the Library module, remove the exclamation points after 'Ask Us!' and 'Tell Us!'.
- In the Library module, rename 'Locations & Hours' to 'Hours & Locations'.
- In the Tours module, have the 'More about Guided Tours' link go to this page 'web.mit.edu/institute-events/events/tour.html'.

Note the version bump to 4.0.2.1, rather than 4.0.3. I opted for this because there is already existing work in progress marked as 4.0.3. If we decide that we would like _this_ change to represent 4.0.3, then we can do that, but it's slightly more work to rename/reorganize the relevant branches.
